### PR TITLE
Request specification to use hetzner.hcloud.hcloud_volume instead of the standard hcloud_volume

### DIFF
--- a/roles/hetznerserver/tasks/main.yml
+++ b/roles/hetznerserver/tasks/main.yml
@@ -12,7 +12,7 @@
   register: server
 
 - name: create and mount a volume
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{server_hostname}}-volume"
     server: "{{server_hostname}}"
     format: ext4


### PR DESCRIPTION
I had troubles without my modified code, as in my ansible setup (standard from this main branch), there was an error : the "standard" hcloud_volume doesn't have the property called linux_device (some lines further down the same file).